### PR TITLE
add row_limit with ability to print all

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: diffdf
 Type: Package
 Title: Dataframe Difference Tool
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c( 
     person("Craig" ,"Gower-Page" , email = "craig.gower-page@roche.com" , role = c("cre","aut")),
     person("Kieran", "Martin" , email = "kieran.martin@roche.com" , role = "aut")

--- a/R/ascii_tables.R
+++ b/R/ascii_tables.R
@@ -157,16 +157,20 @@ as_cropped_char <- function(inval, crop_at = 30 ){
 #' 
 #' Generate nice looking table from a data frame
 #' @param dsin dataset 
-#' @param row_limit Maximum number of rows displayed in dataset
+#' @param row_limit Maximum number of rows displayed in dataset (<= 0 means no limit)
 get_table <- function(dsin , row_limit = 10){
     
     if( nrow(dsin) == 0 ) {
         return("")
     }
     
-    display_table <- subset(dsin ,  1:nrow(dsin) < (row_limit + 1) )
+    if( row_limit > 0 ) {
+        display_table <- subset(dsin ,  1:nrow(dsin) < (row_limit + 1) )
+    } else {
+        display_table <- dsin
+    }
     
-    if ( nrow(dsin) > row_limit ){
+    if ( nrow(dsin) > row_limit && row_limit > 0 ){
         
         add_message <- paste0(
             'First ',

--- a/R/issues.R
+++ b/R/issues.R
@@ -51,9 +51,10 @@ get_print_message.default <- function(object) {
 #' Get text from a basic issue, based on the class of the value of the issue
 #'
 #' @param object an object of class issue_basic
-get_print_message.issue <- function(object){
+#' @param row_limit is the row_limit for the table for the issue
+get_print_message.issue <- function(object, row_limit, ...){
     paste(
-        c(attr(object, "message"),  get_table(object) ),
+        c(attr(object, "message"),  get_table(object, row_limit = row_limit) ),
         collapse = '\n'
     )
 }

--- a/R/print.R
+++ b/R/print.R
@@ -4,6 +4,7 @@
 #' Print nicely formatted version of an diffdf object
 #' @param x comparison object created by diffdf().
 #' @param ... Additional arguments (not used)
+#' @param row_limit Max row limit for difference tables (<= 0 for all rows)
 #' @param as_string Return printed message as an R character vector? 
 #' @examples
 #' x <- subset( iris , -Species )
@@ -12,7 +13,7 @@
 #' print( COMPARE )
 #' print( COMPARE , "Sepal.Length" )
 #' @export 
-print.diffdf <- function(x, ..., as_string = FALSE){
+print.diffdf <- function(x, ..., row_limit = 10, as_string = FALSE){
     COMPARE <- x
 
     if ( length(COMPARE) == 0 ){
@@ -25,13 +26,13 @@ print.diffdf <- function(x, ..., as_string = FALSE){
             'A summary is given below.\n\n'
         )
 
-        end_text <- lapply(COMPARE, function(x) get_print_message(x) ) 
+        end_text <- lapply(COMPARE, function(x) get_print_message(x, row_limit) ) 
         end_text <- paste0(unlist(end_text), collapse = "")
 
         outtext <- paste0(start_text, end_text)
     }
     
-    if ( as_string){
+    if ( as_string ) {
         return(strsplit(outtext, '\n')[[1]])
     } else {
         cat(outtext)

--- a/man/get_print_message.issue.Rd
+++ b/man/get_print_message.issue.Rd
@@ -4,10 +4,12 @@
 \alias{get_print_message.issue}
 \title{get_print_message.issue}
 \usage{
-\method{get_print_message}{issue}(object)
+\method{get_print_message}{issue}(object, row_limit, ...)
 }
 \arguments{
 \item{object}{an object of class issue_basic}
+
+\item{row_limit}{is the row_limit for the table for the issue}
 }
 \description{
 Get text from a basic issue, based on the class of the value of the issue

--- a/man/get_table.Rd
+++ b/man/get_table.Rd
@@ -9,7 +9,7 @@ get_table(dsin, row_limit = 10)
 \arguments{
 \item{dsin}{dataset}
 
-\item{row_limit}{Maximum number of rows displayed in dataset}
+\item{row_limit}{Maximum number of rows displayed in dataset (<= 0 means no limit)}
 }
 \description{
 Generate nice looking table from a data frame

--- a/man/print.diffdf.Rd
+++ b/man/print.diffdf.Rd
@@ -4,12 +4,14 @@
 \alias{print.diffdf}
 \title{Print diffdf objects}
 \usage{
-\method{print}{diffdf}(x, ..., as_string = FALSE)
+\method{print}{diffdf}(x, ..., row_limit = 10, as_string = FALSE)
 }
 \arguments{
 \item{x}{comparison object created by diffdf().}
 
 \item{...}{Additional arguments (not used)}
+
+\item{row_limit}{Max row limit for difference tables (<= 0 for all rows)}
 
 \item{as_string}{Return printed message as an R character vector?}
 }


### PR DESCRIPTION
This pull request adds back the ability to print a diffdf object with a customizable row_limit as well as no row_limit (if set to a non-positive integer)